### PR TITLE
Update IT-glue-BitLocker-Documentation.ps1

### DIFF
--- a/IT-glue-BitLocker-Documentation.ps1
+++ b/IT-glue-BitLocker-Documentation.ps1
@@ -18,7 +18,7 @@ $PasswordObject = @{
     type = 'passwords'
     attributes = @{
             name = $PasswordObjectName
-            password = $BitlockVolume.KeyProtector.recoverypassword[1]
+            password = [string]$BitlockVolume.KeyProtector.recoverypassword
             notes = "Bitlocker key for $($Env:COMPUTERNAME)"
 
     }


### PR DESCRIPTION
As the recovery password doesn't always exist in the second array element, converting to string will allow it to print out the key regardless if its in the first or second array element. This does add a space character to the output though at the beginning or end depending on the array element it is in.